### PR TITLE
fix: replace remaining npx with bunx in security workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -93,10 +93,10 @@ jobs:
       - name: Run license scan
         run: |
           echo "📜 Checking license compliance..."
-          npx license-checker --summary
+          bunx license-checker --summary
           
           # Check for problematic licenses (safer approach)
-          problematic_licenses=$(npx license-checker --excludePrivatePackages --json 2>/dev/null | jq -r 'to_entries[] | select(.value.licenses | type == "string" and (contains("GPL") or contains("AGPL") or contains("LGPL") or contains("UNLICENSED"))) | .key + ": " + .value.licenses' 2>/dev/null || echo "")
+          problematic_licenses=$(bunx license-checker --excludePrivatePackages --json 2>/dev/null | jq -r 'to_entries[] | select(.value.licenses | type == "string" and (contains("GPL") or contains("AGPL") or contains("LGPL") or contains("UNLICENSED"))) | .key + ": " + .value.licenses' 2>/dev/null || echo "")
           
           if [ -n "$problematic_licenses" ]; then
             echo "⚠️ Found potentially problematic licenses:"


### PR DESCRIPTION
## Summary

- Replace remaining `npx` occurrences with `bunx` in security-scan.yml workflow
- Complete the transition to Bun package manager for consistency across all workflows
- Affects license scanning steps in the security workflow

## Changes Made

- `npx license-checker --summary` → `bunx license-checker --summary`
- `npx license-checker --excludePrivatePackages` → `bunx license-checker --excludePrivatePackages`

## Test Plan

- [x] Security workflow runs successfully with `bunx` commands
- [x] License scanning functionality remains unchanged
- [x] No breaking changes to existing workflow behavior
- [x] All other workflows continue to use `bunx` consistently