### PR TITLE
Fix Claude Code reviews for Dependabot PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,6 +61,9 @@ jobs:
           # Security: Restrict to read-only operations and safe build commands
           allowed_tools: "Bash(bun run test),Bash(bun run check),Bash(bun run lint)"
 
+          # Allow Dependabot to trigger Claude reviews for dependency updates
+          allowed_bots: "dependabot"
+
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           custom_instructions: |
             Follow our TypeScript and Biome coding standards


### PR DESCRIPTION
## Problem Fixed
Dependabot PRs were failing with this error:
```
Workflow initiated by non-human actor: dependabot (type: Bot). 
Add bot to allowed_bots list or use '*' to allow all bots.
```

## Solution
- Added `allowed_bots: "dependabot"` parameter to Claude workflow
- Enables Claude to automatically review Dependabot dependency update PRs
- Maintains security restrictions while allowing automated reviews

## Benefits
- ✅ Automated Claude reviews for dependency updates  
- ✅ Enhanced code quality checks on all PRs (including bot PRs)
- ✅ Consistent review process across human and bot-initiated changes
- ✅ Maintains security - only allows specifically approved bots

## Testing
- Verified fix works on PR #30 (Claude review now passes)
- Tested with Dependabot PR and Claude successfully completed review
- No impact on human-initiated PRs (existing functionality preserved)

## Risk Assessment
**Risk Level**: Very Low
- Single parameter addition to existing workflow
- Only affects bot actor restrictions 
- No changes to security model or permissions
- Backwards compatible with existing functionality