### PR TITLE
hotfix(github): enable issue templates by fixing blank_issues_enabled configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 📖 Documentation
     url: https://github.com/gander-tools/mikrus/blob/main/README.md


### PR DESCRIPTION
## 🐛 **Issue Fixed**

**Problem**: New Issue dialog only shows custom contact links (Security, Documentation, Discussion) but **missing Feature Request and Bug Report templates**.

**Root Cause**:  in  **disables all issue templates**.

## 🔧 **Solution**

Changed  →  in config.yml

## ✅ **Result After Fix**

New Issue dialog will now show:
- 🚀 **[FEATURE] Feature Request** ← **NOW VISIBLE** 
- 🐛 **[BUG] Bug Report** ← **NOW VISIBLE**
- 📖 Documentation (existing contact link)
- 🔒 Security Issue (existing contact link) 
- 💬 Discussion (existing contact link)

## 🎯 **Impact**

- ✅ **Contributors can now create proper feature requests and bug reports**
- ✅ **AI auto-tagging workflow will work on new issues**  
- ✅ **Maintains all existing contact links**
- ✅ **No breaking changes**

## 🚨 **Urgency: HOTFIX**

This is a **critical functionality issue** - users cannot create issues using our new templates without this fix.

**Immediate merge recommended** to restore issue template functionality.