### PR TITLE
fix: disable Claude Code Review workflow and add troubleshooting

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,10 @@
-name: Claude Code Review
+name: Claude Code Review (Disabled - Missing OAuth Token)
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  # Temporarily disabled until CLAUDE_CODE_OAUTH_TOKEN is configured
+  workflow_dispatch:
+  # pull_request:
+  #   types: [opened, synchronize]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -76,4 +78,12 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
+
+# TROUBLESHOOTING:
+# This workflow is disabled because CLAUDE_CODE_OAUTH_TOKEN secret is missing.
+# To re-enable:
+# 1. Go to Settings → Secrets and variables → Actions
+# 2. Add repository secret: CLAUDE_CODE_OAUTH_TOKEN 
+# 3. Generate token from Claude Code dashboard
+# 4. Uncomment the pull_request trigger above
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,10 +1,8 @@
-name: Claude Code Review (Disabled - Missing OAuth Token)
+name: Claude Code Review
 
 on:
-  # Temporarily disabled until CLAUDE_CODE_OAUTH_TOKEN is configured
-  workflow_dispatch:
-  # pull_request:
-  #   types: [opened, synchronize]
+  pull_request:
+    types: [opened, synchronize]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -39,6 +37,7 @@ jobs:
         uses: anthropics/claude-code-action@v1.0.1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"
@@ -79,11 +78,9 @@ jobs:
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
 
-# TROUBLESHOOTING:
-# This workflow is disabled because CLAUDE_CODE_OAUTH_TOKEN secret is missing.
-# To re-enable:
-# 1. Go to Settings → Secrets and variables → Actions
-# 2. Add repository secret: CLAUDE_CODE_OAUTH_TOKEN 
-# 3. Generate token from Claude Code dashboard
-# 4. Uncomment the pull_request trigger above
+# ORGANIZATION SECRETS:
+# Uses organization-level secrets for Claude Code integration:
+# - CLAUDE_CODE_OAUTH_TOKEN: OAuth token for Claude Code API access
+# - ANTHROPIC_API_KEY: Anthropic API key for Claude model access
+# Both secrets are configured at the organization level for security
 


### PR DESCRIPTION
## Summary
Temporarily disable Claude Code Review workflow due to missing OAuth token and provide comprehensive troubleshooting guide.

### 🚨 Issue Resolved
- **Workflow Hanging**: Claude Code Review workflow was causing PR blocks
- **Missing Secret**: CLAUDE_CODE_OAUTH_TOKEN secret not configured in repository
- **PR Blocking**: Workflow failure was preventing PR merges

### 🛠️ Immediate Fix
- **Workflow Disabled**: Changed trigger from `pull_request` to `workflow_dispatch` only
- **Clear Documentation**: Added troubleshooting section with step-by-step resolution
- **Title Update**: Updated workflow name to indicate disabled status

### 📋 Changes Made
```yaml
# Before (causing blocks)
on:
  pull_request:
    types: [opened, synchronize]

# After (manual only)  
on:
  workflow_dispatch:
  # pull_request:
  #   types: [opened, synchronize]
```

### 📖 Troubleshooting Guide Added
```yaml
# TROUBLESHOOTING:
# This workflow is disabled because CLAUDE_CODE_OAUTH_TOKEN secret is missing.
# To re-enable:
# 1. Go to Settings → Secrets and variables → Actions
# 2. Add repository secret: CLAUDE_CODE_OAUTH_TOKEN 
# 3. Generate token from Claude Code dashboard
# 4. Uncomment the pull_request trigger above
```

### 🎯 Benefits
- **Unblocked PRs**: No more workflow failures blocking PR merges
- **Manual Control**: Workflow can still be triggered manually for testing
- **Clear Resolution Path**: Detailed steps for future re-enablement
- **Maintained Functionality**: All workflow logic preserved for future use

### 🔄 Re-enablement Process
1. **Generate OAuth Token**: From Claude Code dashboard
2. **Configure Repository Secret**: Add CLAUDE_CODE_OAUTH_TOKEN in Settings
3. **Update Workflow**: Uncomment pull_request trigger
4. **Test Functionality**: Verify workflow runs successfully

## Test Plan
- [ ] Workflow no longer triggers on pull requests
- [ ] Manual workflow dispatch available and functional
- [ ] No workflow failures blocking PR merges
- [ ] Troubleshooting documentation clear and actionable
- [ ] All workflow steps preserved for future re-enablement
- [ ] Repository can proceed with normal development workflow