### PR TITLE
fix: simplify packages workflow - Linux only, no releases

### DIFF
--- a/.github/workflows/packages-distribution.yml
+++ b/.github/workflows/packages-distribution.yml
@@ -1,7 +1,7 @@
 name: "📦 GitHub Packages Distribution"
 
-# Multi-platform binary distribution to GitHub Packages
-# Builds stable packages for Windows, Linux, macOS (x86_64 + ARM64)
+# Linux x86_64 binary distribution to GitHub Packages
+# Builds stable packages for Linux x86_64 only
 # STABILITY RULES:
 # - Before v0.1.0: stable = no active code fix PRs (development phase)
 # - v0.1.0+ (pre-production milestone): stable = semantic versioning tags only
@@ -150,21 +150,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
             output: mikrus-linux-x64
             artifact: linux-x64
-          - name: "Windows x86_64"
-            os: windows-latest
-            target: x86_64-pc-windows-msvc
-            output: mikrus-windows-x64.exe
-            artifact: windows-x64
-          - name: "macOS x86_64"
-            os: macos-latest
-            target: x86_64-apple-darwin
-            output: mikrus-macos-x64
-            artifact: macos-x64
-          - name: "macOS ARM64"
-            os: macos-latest
-            target: aarch64-apple-darwin
-            output: mikrus-macos-arm64
-            artifact: macos-arm64
 
     steps:
       - name: "📥 Checkout Repository"
@@ -477,55 +462,3 @@ jobs:
           echo "- \`${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:${{ steps.packages_dist_version.outputs.VERSION }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:latest\`" >> $GITHUB_STEP_SUMMARY
 
-  # Phase 3: GitHub Release (Optional)
-  create-github-release:
-    name: "🎉 Create GitHub Release"
-    runs-on: ubuntu-latest
-    needs: [build-binaries, distribute-packages]
-    permissions:
-      contents: write
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    
-    steps:
-      - name: "📥 Checkout Repository"
-        id: packages_release_checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-
-      - name: "🏷️ Extract Version Information"
-        id: packages_release_version
-        run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "FULL_VERSION=v$VERSION" >> $GITHUB_OUTPUT
-
-      - name: "📥 Download All Artifacts"
-        id: packages_release_download
-        uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
-        with:
-          path: ./artifacts
-
-      - name: "🎉 Create GitHub Release"
-        id: packages_create_release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        with:
-          tag_name: ${{ steps.packages_release_version.outputs.FULL_VERSION }}
-          name: "mikrus CLI ${{ steps.packages_release_version.outputs.FULL_VERSION }}"
-          draft: false
-          prerelease: false
-          generate_release_notes: true
-          files: |
-            artifacts/mikrus-linux-x64/mikrus-linux-x64
-            artifacts/mikrus-windows-x64/mikrus-windows-x64.exe  
-            artifacts/mikrus-macos-x64/mikrus-macos-x64
-            artifacts/mikrus-macos-arm64/mikrus-macos-arm64
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "🎉 Release Summary"
-        id: packages_release_summary
-        run: |
-          echo "## 🎉 GitHub Release Created" >> $GITHUB_STEP_SUMMARY
-          echo "- **Release**: ${{ steps.packages_release_version.outputs.FULL_VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **URL**: https://github.com/${{ github.repository }}/releases/tag/${{ steps.packages_release_version.outputs.FULL_VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Assets**: 4 platform binaries" >> $GITHUB_STEP_SUMMARY
-          echo "- **Type**: Stable Release" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Simplify GitHub Packages Distribution workflow to build only Linux x86_64 binaries without GitHub releases.

### 🔧 Changes Made
- **Platform Reduction**: Remove Windows, macOS x86_64, macOS ARM64 from build matrix
- **Linux Only**: Keep only Linux x86_64 binary compilation  
- **No GitHub Releases**: Remove entire `create-github-release` job
- **Simplified Description**: Update workflow description to reflect Linux-only builds

### 📦 What Remains
- **✅ Stability Validation**: Pre-build stability rules checking
- **✅ Linux Binary Build**: Single platform compilation (x86_64-unknown-linux-gnu)
- **✅ GitHub Packages**: Container distribution to GitHub Container Registry
- **✅ Package Management**: Automated cleanup and version management

### 🚫 What's Removed
- **❌ Windows Build**: No Windows x86_64 binary
- **❌ macOS Builds**: No x86_64 or ARM64 macOS binaries  
- **❌ GitHub Releases**: No automatic GitHub releases creation
- **❌ Multi-platform Assets**: No release assets upload

### 🎯 Benefits
- **Faster Builds**: Single platform compilation reduces build time
- **Simplified Maintenance**: Less complexity in workflow management
- **Focus on Containers**: GitHub Packages distribution for containerized usage
- **No Release Overhead**: Eliminates GitHub release automation complexity

### 🔧 Workflow Structure (After Changes)
```yaml
Jobs:
  1. 🔍 Stability Validation
  2. 🔨 Build Linux x86_64  
  3. 📦 Distribute Packages
  # 4. ❌ Create GitHub Release - REMOVED
```

## Test Plan
- [ ] Workflow triggers correctly with `workflow_dispatch`
- [ ] Stability validation passes for v0.0.x versions
- [ ] Linux binary compiles successfully
- [ ] GitHub Packages distribution works
- [ ] No GitHub release creation occurs
- [ ] Build time reduced compared to multi-platform workflow