### PR TITLE
fix(ci): remove final emoji characters from PowerShell commands

### DIFF
--- a/.github/workflows/deno-release.yml
+++ b/.github/workflows/deno-release.yml
@@ -271,7 +271,7 @@ jobs:
         if: runner.os == 'Windows'
         id: analysis-windows
         run: |
-          Write-Host "📊 Analyzing binary on Windows..."
+          Write-Host "Analyzing binary on Windows..."
           
           # Get file size using PowerShell
           $filePath = "./dist/${{ matrix.platform.output }}"
@@ -281,7 +281,7 @@ jobs:
           
           # Set GitHub output
           echo "BINARY_SIZE_MB=$SIZE_MB" >> $env:GITHUB_OUTPUT
-          Write-Host "📦 Binary size: ${SIZE_MB}MB"
+          Write-Host "Binary size: ${SIZE_MB}MB"
           
           # Create SHA256 checksum
           Write-Host "Creating checksum..."
@@ -327,13 +327,13 @@ jobs:
       - name: "📊 Build Summary (Windows)"
         if: runner.os == 'Windows'
         run: |
-          echo "## 🔨 ${{ matrix.platform.name }} Build Complete" >> $env:GITHUB_STEP_SUMMARY
+          echo "## Build ${{ matrix.platform.name }} Complete" >> $env:GITHUB_STEP_SUMMARY
           echo "" >> $env:GITHUB_STEP_SUMMARY
           echo "- **Target**: ${{ matrix.platform.target }}" >> $env:GITHUB_STEP_SUMMARY
           echo "- **Binary**: ${{ matrix.platform.output }}" >> $env:GITHUB_STEP_SUMMARY
           echo "- **Size**: ${{ steps.analysis-windows.outputs.BINARY_SIZE_MB }}MB" >> $env:GITHUB_STEP_SUMMARY
           echo "- **Version**: ${{ needs.stability-check.outputs.tag }}" >> $env:GITHUB_STEP_SUMMARY
-          echo "- **Status**: ✅ Success" >> $env:GITHUB_STEP_SUMMARY
+          echo "- **Status**: Success" >> $env:GITHUB_STEP_SUMMARY
         shell: powershell
 
       - name: "📊 Build Summary (Unix)"
@@ -452,7 +452,7 @@ jobs:
           # Verify checksum (PowerShell)
           \$hash = Get-FileHash -Path "mikrus.exe" -Algorithm SHA256
           \$expected = Get-Content "mikrus-windows-x64.exe.sha256"
-          if (\$hash.Hash -eq \$expected.Split()[0]) { Write-Host "✅ Checksum verified" } else { Write-Host "❌ Checksum mismatch" }
+          if (\$hash.Hash -eq \$expected.Split()[0]) { Write-Host "Checksum verified" } else { Write-Host "Checksum mismatch" }
           \`\`\`
           
           #### macOS


### PR DESCRIPTION
## Summary

Removes the final remaining emoji characters from PowerShell commands in the Windows build workflow that are causing encoding errors and preventing successful Windows binary builds.

### Issue

The previous PR #86 fixed most PowerShell encoding issues, but a few emoji characters remained in the Windows Binary Analysis step:

```powershell
Write-Host "📊 Analyzing binary on Windows..."    # ❌ Causes encoding error
Write-Host "📦 Binary size: ${SIZE_MB}MB"        # ❌ Causes encoding error  
```

### Fix

Replace remaining emoji with plain text:

```powershell
Write-Host "Analyzing binary on Windows..."       # ✅ Works correctly
Write-Host "Binary size: ${SIZE_MB}MB"           # ✅ Works correctly
```

Also removes emoji from:
- PowerShell release notes checksum verification example
- Windows build summary step

### Test Results

**Current Workflow Status:**
- ✅ Linux x86_64: Build successful
- ✅ macOS x86_64: Build successful  
- ❌ Windows x86_64: Fails due to PowerShell emoji encoding

**Expected After Fix:**
- ✅ Linux x86_64: Continue working
- ✅ macOS x86_64: Continue working
- ✅ Windows x86_64: Build successful

## Risk Assessment

**No Risk Changes:**
- Only removes emoji characters from diagnostic messages
- No functional logic changes
- Windows builds will work instead of failing
- Linux and macOS builds unaffected

## Verification

This completes the multi-platform build fix started in PR #86. After merge:
1. All three platforms (Linux, Windows, macOS) will build successfully  
2. Complete release workflow will work end-to-end
3. GitHub releases will contain all platform binaries and checksums

Related: PR #86 (Multi-platform build failures)
Fixes: Windows PowerShell emoji encoding errors