### PR TITLE
fix: correct critical type mismatch in template findById method

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -30,7 +30,7 @@ export class <%= name %>Service {
     return this.models;
   }
 
-  findById(id: number): <%= name %>Model | undefined {
+  findById(id: string): <%= name %>Model | undefined {
     return this.models.find(model => model.id === id);
   }
 }


### PR DESCRIPTION
## Critical Bug Fix

**Identified by Claude Code Review workflow #17335973588**

### Issue
Template in `src/commands/generate.ts` had a type mismatch:
- Interface defines `id: string` (line 8)
- Method parameter was `id: number` (line 33)

### Fix
- Changed `findById(id: number)` → `findById(id: string)`
- Ensures type consistency between interface and service method
- Maintains compatibility with UUID-based id generation (`crypto.randomUUID()`)

### Impact
- **Critical**: Prevents runtime type errors in generated code
- **Safety**: Ensures TypeScript compilation success
- **Compatibility**: Aligns with existing UUID-based id system

### Testing
- ✅ All linting, formatting, and type checks pass
- ✅ Template generates valid TypeScript code
- ✅ Interface and method signatures are now consistent

**Priority: CRITICAL** - This fix prevents type errors in user-generated code.