### PR TITLE
ci: fix workflow branch references to master

### DIFF
--- a/.github/workflows/deno-ci.yml
+++ b/.github/workflows/deno-ci.yml
@@ -1,14 +1,14 @@
 name: "🦕 Deno CI/CD Pipeline"
 
-# Deno-specific continuous integration workflow for the experimental branch
-# Triggers: Push/PR to feature/deno-cliffy-experiment branch + manual dispatch
+# Deno-specific continuous integration workflow for master branch  
+# Triggers: Push/PR to master branch + manual dispatch
 # Jobs: lint-and-format → test → build → security-audit → integration-test → notify
 
 on:
   push:
-    branches: [main-deno, feature/deno-cliffy-experiment]
+    branches: [master]
   pull_request:
-    branches: [main-deno]
+    branches: [master]
     paths:
       - "deno.json"
       - "src/**"

--- a/.github/workflows/deno-comprehensive-security-audit.yml
+++ b/.github/workflows/deno-comprehensive-security-audit.yml
@@ -10,14 +10,13 @@ on:
     - cron: "0 2 * * *"
   push:
     branches: [
-      main-deno,
-      feature/deno-cliffy-experiment,
+      master,
       feature/*,
       fix/*,
       hotfix/*,
     ]
   pull_request:
-    branches: [main-deno]
+    branches: [master]
   workflow_call:
     secrets:
       SNYK_TOKEN:


### PR DESCRIPTION
- Remove obsolete main-deno and feature/deno-cliffy-experiment branch references
- Update deno-ci.yml triggers to target master branch instead of experimental branches
- Update deno-comprehensive-security-audit.yml to use master as base branch
- Fixes workflow trigger failures caused by referencing non-existent branches
- Resolves issues stemming from completed Deno migration in PR #54
