### PR TITLE
feat: hide generate command for internal use only

### DIFF
--- a/.github/workflows/deno-ci.yml
+++ b/.github/workflows/deno-ci.yml
@@ -297,12 +297,22 @@ jobs:
             exit 1
           fi
 
+          echo "✅ Help command test passed"
+
+      - name: "🔍 Integration: CLI Internal Help Command Test"
+        id: deno_test_internal_help_command
+        run: |
+          echo "🔍 Testing CLI internal help command..."
+          output=$(MIKRUS_INTERNAL=true ./build/mikrus-linux --help)
+          echo "$output"
+
+          # In internal mode, generate command should be visible
           if ! echo "$output" | grep -q "generate"; then
-            echo "❌ ERROR: Help output does not contain generate command"
+            echo "❌ ERROR: Help output does not contain generate command in internal mode"
             exit 1
           fi
 
-          echo "✅ Help command test passed"
+          echo "✅ Internal help command test passed"
 
       - name: "📋 Integration: CLI Version Command Test"
         id: deno_test_version_command
@@ -321,14 +331,14 @@ jobs:
       - name: "📄 Integration: CLI Generate Command Test"
         id: deno_test_generate_command
         run: |
-          echo "📄 Testing CLI generate command..."
+          echo "📄 Testing CLI generate command in internal mode..."
 
           # Create a temporary directory for testing
           mkdir -p test-output
           cd test-output
 
-          # Test generate command
-          output=$(../build/mikrus-linux generate test-integration-model)
+          # Test generate command with internal mode
+          output=$(MIKRUS_INTERNAL=true ../build/mikrus-linux generate test-integration-model)
           echo "$output"
 
           # Verify file was created
@@ -358,10 +368,10 @@ jobs:
       - name: "🛡️ Integration: Security Validation Test"
         id: deno_test_security_validation
         run: |
-          echo "🛡️ Testing security validation..."
+          echo "🛡️ Testing security validation in internal mode..."
 
           # Test path traversal protection
-          if ./build/mikrus-linux generate "../malicious-file" 2>&1 | grep -q "Path traversal detected"; then
+          if MIKRUS_INTERNAL=true ./build/mikrus-linux generate "../malicious-file" 2>&1 | grep -q "Path traversal detected"; then
             echo "✅ Path traversal protection working"
           else
             echo "❌ ERROR: Path traversal protection failed"
@@ -369,7 +379,7 @@ jobs:
           fi
 
           # Test command injection protection
-          if ./build/mikrus-linux generate "file; rm -rf /" 2>&1 | grep -q "Invalid characters detected"; then
+          if MIKRUS_INTERNAL=true ./build/mikrus-linux generate "file; rm -rf /" 2>&1 | grep -q "Invalid characters detected"; then
             echo "✅ Command injection protection working"
           else
             echo "❌ ERROR: Command injection protection failed"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,8 +19,8 @@ import { GIT_HASH, VERSION } from "./version.ts";
 async function run(args: string[] = Deno.args): Promise<void> {
   try {
     // Check for internal mode for generate command visibility
-    const internalMode = Deno.env.get("MIKRUS_INTERNAL") === "true" || 
-                        args.includes("--internal");
+    const internalMode = Deno.env.get("MIKRUS_INTERNAL") === "true" ||
+      args.includes("--internal");
 
     // Create main CLI command with enhanced configuration
     const cli = new Command()
@@ -31,7 +31,7 @@ async function run(args: string[] = Deno.args): Promise<void> {
       .version(`${VERSION} (${GIT_HASH})`)
       // Enhanced help with examples (conditional on internal mode)
       .example(
-        internalMode ? "Generate a model file" : "Show version", 
+        internalMode ? "Generate a model file" : "Show version",
         internalMode ? "mikrus generate user" : "mikrus --version",
       )
       .example(
@@ -64,7 +64,9 @@ async function run(args: string[] = Deno.args): Promise<void> {
           if (error.message.includes("Unknown command")) {
             console.log(yellow("\n💡 Available commands:"));
             if (internalMode) {
-              console.log("  generate  Generate a new model file from template");
+              console.log(
+                "  generate  Generate a new model file from template",
+              );
             }
             console.log("\nTry: mikrus --help");
           }


### PR DESCRIPTION
## Summary
- Add environment variable MIKRUS_INTERNAL=true or --internal flag to enable generate command
- Generate command is now hidden from regular CLI usage
- Command will be used internally for configuration generation and future file generation
- Updated help examples to be contextual based on internal mode

## Changes
- Modified CLI initialization to check for internal mode
- Generate command only registered when MIKRUS_INTERNAL=true or --internal flag present
- Conditional help examples and error messages
- Maintains backwards compatibility for internal usage

## Testing
- Regular CLI usage: `mikrus --help` (generate command not visible)
- Internal usage: `MIKRUS_INTERNAL=true mikrus --help` (generate command visible)
- Internal usage: `mikrus --internal --help` (generate command visible)

## Future Use
This prepares the generate command for:
- Initial configuration generation
- Template-based file generation
- Internal tooling workflows