### PR TITLE
ci: configure Claude Code Review to trigger after master merges

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,10 @@
 name: Claude Code Review
 
 on:
-  # Manual trigger only - run on demand for specific PRs
+  # Trigger after merges to master branch
+  push:
+    branches: [master]
+  # Manual trigger for specific PRs
   workflow_dispatch:
     inputs:
       pr_number:
@@ -23,6 +26,8 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     steps:
       - name: Get PR Context
@@ -34,9 +39,20 @@ jobs:
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
             echo "Reviewing PR #${{ github.event.pull_request.number }}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            # For push events, find the most recent merged PR
+            echo "Push to master detected - finding most recent merged PR..."
+            RECENT_PR=$(gh pr list --state merged --limit 1 --json number --jq '.[0].number')
+            if [ -n "$RECENT_PR" ]; then
+              echo "PR_NUMBER=$RECENT_PR" >> $GITHUB_OUTPUT
+              echo "Reviewing recently merged PR #$RECENT_PR"
+            else
+              echo "No recent merged PRs found. Skipping review."
+              exit 0
+            fi
           else
-            echo "No PR number provided. Please specify a PR number when triggering manually."
-            exit 1
+            echo "No PR context available. Skipping review."
+            exit 0
           fi
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary
Configure Claude Code Review workflow to automatically trigger after PRs are merged to master branch.

## Changes
- **Add push trigger** for master branch to auto-review merged PRs  
- **Maintain manual trigger** option for specific PR reviews
- **Add GH_TOKEN environment** for GitHub CLI access in workflow
- **Auto-detect most recent merged PR** when triggered by push events
- **Graceful handling** when no recent PRs found

## Workflow Logic
1. **On push to master**: Finds most recent merged PR and reviews it
2. **On manual dispatch**: Reviews specified PR number
3. **Fallback behavior**: Skips gracefully if no PR context available

## Benefits
- **Automatic post-merge review** for quality assurance
- **Continuous feedback loop** on merged code
- **Flexible triggering** (automatic + manual)
- **No duplicate reviews** - focuses on recently merged changes

This ensures code quality validation happens consistently after merges while maintaining manual review capabilities.