### PR TITLE
fix: claude-code-review workflow final fixes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,11 @@ on:
   # Trigger after merges to master branch
   push:
     branches: [master]
+  # Trigger on PRs for testing workflow changes
+  pull_request:
+    branches: [master]
+    paths:
+      - '.github/workflows/claude-code-review.yml'
   # Manual trigger for specific PRs
   workflow_dispatch:
     inputs:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,31 +41,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Get PR Context
-        id: pr_context
-        run: |
-          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
-            echo "PR_NUMBER=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
-            echo "Reviewing PR #${{ github.event.inputs.pr_number }}"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-            echo "Reviewing PR #${{ github.event.pull_request.number }}"
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            # For push events, find the most recent merged PR
-            echo "Push to master detected - finding most recent merged PR..."
-            RECENT_PR=$(gh pr list --state merged --limit 1 --json number --jq '.[0].number')
-            if [ -n "$RECENT_PR" ]; then
-              echo "PR_NUMBER=$RECENT_PR" >> $GITHUB_OUTPUT
-              echo "Reviewing recently merged PR #$RECENT_PR"
-            else
-              echo "No recent merged PRs found. Skipping review."
-              exit 0
-            fi
-          else
-            echo "No PR context available. Skipping review."
-            exit 0
-          fi
-
       - name: Run Claude Code Review
         id: deno_claude_review
         uses: anthropics/claude-code-action@a6888c03f22170d00d2a92fa2317584ca7d5e108 # v1.0
@@ -73,10 +48,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.CLAUDE_CODE_REVIEW_PAT }}
-          pr_number: ${{ steps.pr_context.outputs.PR_NUMBER }}
-
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
 
           # Direct prompt for automated review (no @claude mention needed)
           prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,14 +1,9 @@
 name: Claude Code Review
 
 on:
-  # Trigger after merges to master branch
-  push:
-    branches: [master]
-  # Trigger on PRs for testing workflow changes
+  # Trigger on PRs for code review
   pull_request:
     branches: [master]
-    paths:
-      - '.github/workflows/claude-code-review.yml'
   # Manual trigger for specific PRs
   workflow_dispatch:
     inputs:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,6 +30,12 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     steps:
+      - name: Checkout repository
+        id: deno_claude_checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 1
+
       - name: Get PR Context
         id: pr_context
         run: |
@@ -54,12 +60,6 @@ jobs:
             echo "No PR context available. Skipping review."
             exit 0
           fi
-
-      - name: Checkout repository
-        id: deno_claude_checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 1
 
       - name: Run Claude Code Review
         id: deno_claude_review


### PR DESCRIPTION
## Summary

Final fixes for Claude Code Review workflow to make it work correctly.

## Changes Made

1. **Fixed repository checkout order** - Moved checkout step before any git commands
2. **Removed unsupported pr_number parameter** - Claude action auto-detects PR context
3. **Simplified workflow logic** - Removed manual PR context detection
4. **Removed push trigger** - Action only supports pull_request events, not push

## Testing

✅ Workflow now runs successfully on pull requests
✅ No more "fatal: not a git repository" errors  
✅ No more "Unexpected input pr_number" warnings
✅ No more "Unsupported event type: push" errors

## Result

Claude Code Review workflow is now fully functional for PR reviews.