### PR TITLE
fix: remove duplicate pull_request trigger in Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,11 +4,6 @@ on:
   # Trigger on PRs for code review
   pull_request:
     branches: [master]
-  # Trigger on PRs for testing workflow changes
-  pull_request:
-    branches: [master]
-    paths:
-      - '.github/workflows/claude-code-review.yml'
   # Manual trigger for specific PRs
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- Fixed invalid YAML syntax in Claude Code Review workflow
- Removed duplicate `pull_request` trigger that was causing workflow parsing errors

## Problem
The workflow file had two `pull_request` triggers defined, which is invalid YAML syntax and prevents the workflow from running properly.

## Solution
Removed the duplicate trigger that was meant for testing workflow changes, keeping only the main trigger for PRs to master branch.

## Test plan
- [ ] Workflow file now has valid YAML syntax
- [ ] Claude Code Review will trigger on PRs to master
- [ ] Manual workflow_dispatch trigger remains available