### PR TITLE
fix: correct Claude Code Review workflow triggers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,9 +1,10 @@
 name: Claude Code Review
 
 on:
-  # Trigger on push to master (after PR is merged)
-  push:
+  # Trigger on pull requests to master
+  pull_request:
     branches: [master]
+    types: [opened, synchronize, reopened]
   # Manual trigger for full project review
   workflow_dispatch:
 
@@ -79,8 +80,7 @@ jobs:
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
 
-          # Enable tools for running validation checks
-          allowed_tools: "Bash(deno task test),Bash(deno task check),Bash(deno task lint),Bash(deno task fmt:check),Bash(gh workflow list),Read,Grep"
+          # Note: Claude Code Action will have access to standard tools for validation checks
 
           # Optional: Skip review for certain conditions
           # if: |


### PR DESCRIPTION
## Summary
- Fixed Claude Code Review workflow to use correct event triggers
- Removed unsupported configuration parameter

## Problem
The Claude Code Review workflow was failing with error: "Unsupported event type: push"

## Solution  
- Changed trigger from `push` events to `pull_request` events (opened, synchronize, reopened)
- Removed the `allowed_tools` parameter which is not a valid input for the Claude Code Action
- Added clarifying comment about available tools

## Test Plan
This PR itself will trigger the Claude Code Review workflow, validating that the fix works correctly.

## Context
Workflow run #17357861863 was failing due to incorrect trigger configuration. The Claude Code Action only supports `pull_request` and `issue_comment` events, not `push` events.