### PR TITLE
fix: simplify Claude Code Review prompt and clean up workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   claude-review:
-    # Run only when PR is created by user 'gander'
     if: github.event.pull_request.user.login == 'gander'
 
     runs-on: ubuntu-latest
@@ -15,9 +14,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
     steps:
       - name: Checkout repository
         id: deno_claude_checkout
@@ -30,14 +27,9 @@ jobs:
         uses: anthropics/claude-code-action@a6888c03f22170d00d2a92fa2317584ca7d5e108 # v1.0
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.CLAUDE_CODE_REVIEW_PAT }}
 
           prompt: |
-            Please perform a comprehensive code review of the entire project on the master branch.
-            
-            DO NOT run any tests, linters, or Deno commands. Focus solely on code review and analysis.
-            
             Review the following aspects:
             
             ## Code Quality & Architecture


### PR DESCRIPTION
## Summary
- Simplified Claude Code Review workflow configuration
- Streamlined review prompt for better clarity
- Removed unused configuration parameters

## Changes
- Simplified review prompt to start directly with review aspects
- Removed redundant instructions about not running tests/linters
- Removed unused `anthropic_api_key` parameter from action inputs
- Removed unused `GH_TOKEN` environment variable
- Cleaned up comment formatting

## Purpose
Makes the workflow cleaner and more maintainable while preserving functionality:
- Still runs only for PRs from user 'gander'
- Still focuses on code review without test execution
- More concise and easier to understand prompt